### PR TITLE
Moved PullToRefresh dependency from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1983,11 +1983,6 @@
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.7.tgz",
       "integrity": "sha1-wA1cUSi6xYBr7BXSt+fNq+QlMfM="
     },
-    "pulltorefreshjs": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/pulltorefreshjs/-/pulltorefreshjs-0.1.7.tgz",
-      "integrity": "sha512-MymP4GqMTQV4/1MjaeNmcR4aIsMOHP+wCQVBOMLjGCfXLJYvicZb3WEZ8bHN+XfkyKOb5Cxb7yksRQNrXjcNIg=="
-    },
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "express": "^4.16.3",
-    "pug": "^2.0.3",
-    "pulltorefreshjs": "^0.1.7"
+    "pug": "^2.0.3"
   }
 }

--- a/views/layouts/index.pug
+++ b/views/layouts/index.pug
@@ -9,5 +9,5 @@ head
   img#spooky-meter(src=`/images/level${spookylevel}.gif`)
 a#fork-me(href='https://github.com/goibon/spooky-meter')
   img(style='position: absolute; top: 0; left: 0; border: 0;' src='https://camo.githubusercontent.com/8b6b8ccc6da3aa5722903da7b58eb5ab1081adee/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f6f72616e67655f6666373630302e706e67' alt='Fork me on GitHub' data-canonical-src='https://s3.amazonaws.com/github/ribbons/forkme_left_orange_ff7600.png')
-script(type='text/javascript' src='node_modules/pulltorefreshjs/dist/pulltorefresh.min.js')
+script(src='https://cdnjs.cloudflare.com/ajax/libs/pulltorefreshjs/0.1.7/pulltorefresh.min.js' integrity='sha256-+VIA0NmSIMg4hK6exnLiTdIdZ2i0Vt2yov29Nih1afo=' crossorigin='anonymous')
 script(type='text/javascript' src='js/main.mjs')


### PR DESCRIPTION
Thought it's nice to have dependencies gathered in one place, it is ill advised to expose your `node_modules` folder and as such, the script tag pointing to  [`pulltorefresh.js`](https://github.com/BoxFactura/pulltorefresh.js) has been changed to point to cdnjs.
This should also provide better performance when retrieving the script.