### PR TITLE
Added `alt` attribute to image

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ app.get('/', function (request, response) {
   const spookylevel = spookyMeter.getSpookyLevel()
   response.render('layouts/index', {
     spookylevel: spookylevel,
-    title: spookyMeter.getSpookyDescription(spookylevel)
+    spookyDescription: spookyMeter.getSpookyDescription(spookylevel)
   })
 })
 

--- a/public/js/main.mjs
+++ b/public/js/main.mjs
@@ -5,6 +5,7 @@ import('./spookyMeter.js')
 
   function updateSpookyMeterImage (spookyLevel) {
     spookyMeterImage.setAttribute('src', `/images/level${spookyLevel}.gif`)
+    spookyMeterImage.setAttribute('alt', spookyMeter.getSpookyDescription(spookyLevel))
   }
 
   function updateTitle (spookyLevel) {

--- a/views/layouts/index.pug
+++ b/views/layouts/index.pug
@@ -1,7 +1,7 @@
 doctype html
 html(lang='en')
   head
-    title= title
+    title= spookyDescription
     meta(name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no')
     link(rel='icon' href='/favicon.ico' type='image/x-icon')
     link(rel='manifest' href='/site.webmanifest')

--- a/views/layouts/index.pug
+++ b/views/layouts/index.pug
@@ -7,7 +7,7 @@ html(lang='en')
     link(rel='manifest' href='/site.webmanifest')
     link(rel='stylesheet' type='text/css' href='css/main.css')
   .spooky-meter-container
-    img#spooky-meter(src=`/images/level${spookylevel}.gif`)
+    img#spooky-meter(src=`/images/level${spookylevel}.gif` alt=spookyDescription)
   a#fork-me(href='https://github.com/goibon/spooky-meter')
     img(style='position: absolute; top: 0; left: 0; border: 0;' src='https://camo.githubusercontent.com/8b6b8ccc6da3aa5722903da7b58eb5ab1081adee/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f6f72616e67655f6666373630302e706e67' alt='Fork me on GitHub' data-canonical-src='https://s3.amazonaws.com/github/ribbons/forkme_left_orange_ff7600.png')
   script(src='https://cdnjs.cloudflare.com/ajax/libs/pulltorefreshjs/0.1.7/pulltorefresh.min.js' integrity='sha256-+VIA0NmSIMg4hK6exnLiTdIdZ2i0Vt2yov29Nih1afo=' crossorigin='anonymous')


### PR DESCRIPTION
In order to increase accessibility of the site in accordance to #8, the `alt` attribute is now used on the spooky meter image. The `alt` text of the image is the same as the text that is highlighted in the image which is also set as the title of the page when updated.